### PR TITLE
dev build of sentry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN easy_install sentry[postgres]==dev
 
 EXPOSE 9000
 
+VOLUME ["/data"]
+
 ADD sentry_docker_conf.py /conf/
 ADD sentry_run /usr/local/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,6 @@ RUN easy_install sentry[postgres]==dev
 
 EXPOSE 9000
 
-VOLUME ["/data"]
-
 ADD sentry_docker_conf.py /conf/
 ADD sentry_run /usr/local/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN mkdir -p /conf /data /wheels
 ADD requirements.txt /conf/
 
 RUN pip wheel --wheel-dir=/wheels -r /conf/requirements.txt && pip install --find-links=/wheels -r /conf/requirements.txt
+RUN easy_install sentry[postgres]==dev
 
 EXPOSE 9000
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ hiredis==0.1.5
 nydus==0.10.8
 
 # sentry
-sentry[postgres]==6.4.4
+#sentry==dev
 
 # ldap user store
 django-auth-ldap==1.2.3


### PR DESCRIPTION
The latest stable verison 6.4.4 is missing some [features](https://github.com/getsentry/raven-js/issues/299). We need to be able to use the latest dev version of sentry. 

I've created a separate dev branch. Also, I had to use easy_install as dev egg was not able to be located using pip.

Could you please create a new docker build for the dev sentry and tag the docker image as dev?

Thanks