### PR TITLE
Pass SIGTERM to sentry process

### DIFF
--- a/sentry_run
+++ b/sentry_run
@@ -37,5 +37,5 @@ EOF
 fi
 
 if [ "$1" != "prepare" ]; then
-    sentry --config=$SENTRY_CONF_FILE $@
+    exec sentry --config=$SENTRY_CONF_FILE $@
 fi


### PR DESCRIPTION
With this change the process does no longer get killed but receives a proper SIGTERM on shutdown