### PR TITLE
Add support for REMOTE_USER authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ if you want to keep your builds same as before update your Dockerfiles and chang
 
 This is my approach for running [Sentry](https://getsentry.com) inside [Docker](https://docker.com/).
 Almost everything here is configurable via environment variables (including DATABASES and CACHES settings).
-It can be easily configured to run with redis (cache, buffers and celery broker), postgres database and LDAP authentication backend.
+It can be easily configured to run with redis (cache, buffers and celery broker), postgres database, LDAP and REMOTE_USER authentication backends.
 
 ## Quickstart ##
 
@@ -179,6 +179,10 @@ Then set the needed options by adding env variables with ``LDAP_``
 prefix (see the table below). LDAP authentication backend is provided by
 [django-auth-ldap](https://pythonhosted.org/django-auth-ldap/).
 
+###REMOTE_USER
+To enable authentication via REMOTE_USER, add ``SENTRY_USE_REMOTE_USER=True`` to your ``environment`` file.
+See the ``AUTH_REMOTE_USER_*`` env variables below for further configuration.
+
 ## Available environment variables
 
 Refer to [sentry documentation](http://sentry.readthedocs.org/en/latest/config/index.html),
@@ -248,6 +252,8 @@ LDAP_FIND_GROUP_PERMS           | AUTH_LDAP_FIND_GROUP_PERMS                    
 LDAP_CACHE_GROUPS               | AUTH_LDAP_CACHE_GROUPS                        | bool | True                                                  |
 LDAP_GROUP_CACHE_TIMEOUT        | AUTH_LDAP_GROUP_CACHE_TIMEOUT                 | int  | 3600                                                  |
 LDAP_LOGLEVEL                   |                                               |      | ``DEBUG``                                             | django_auth_ldap logger level (other values: NOTSET (to disable), INFO, WARNING, ERROR or CRITICAL)
+SENTRY_USE_REMOTE_USER          |                                               | bool | False                                                 | use `REMOTE_USER` for authentication; useful if you're behind your own SSO
+AUTH_REMOTE_USER_HEADER         |                                               |      | None                                                  | if set, this value will be read from the request object instead of `REMOTE_USER`, as described [here](https://docs.djangoproject.com/en/1.7/howto/auth-remote-user/). For example: `HTTP_X_SSO_USERNAME`
 SENTRY_INITIAL_TEAM             |                                               |      |                                                       | convenient in development - creates an initial team inside Sentry DB with the given name
 SENTRY_INITIAL_PROJECT          |                                               |      |                                                       | convenient in development - creates an initial project for the above team (owner for both is the created admin )
 SENTRY_INITIAL_PLATFORM         |                                               |      | 'python'                                              | convenient in development - indicates a platform for the above initial project

--- a/environment.example
+++ b/environment.example
@@ -6,6 +6,7 @@ SECRET_KEY=
 ### other settings
 ### (https://docs.djangoproject.com/en/1.5/ref/settings/)
 ### (http://sentry.readthedocs.org/en/latest/config/index.html)
+
 ## celery
 #CELERY_ALWAYS_EAGER=False
 #SENTRY_BROKER_URL=redis://redis:6379/1
@@ -75,6 +76,10 @@ SECRET_KEY=
 #LDAP_CACHE_GROUPS=True
 #LDAP_GROUP_CACHE_TIMEOUT=3600
 
+
+## REMOTE_USER (https://docs.djangoproject.com/en/stable/howto/auth-remote-user/)
+#SENTRY_USE_REMOTE_USER=True
+#AUTH_REMOTE_USER_HEADER=HTTP_X_SSO_USERNAME
 
 ## others
 #SENTRY_ALLOW_REGISTRATION=True

--- a/sentry_docker_conf.py
+++ b/sentry_docker_conf.py
@@ -6,6 +6,7 @@ import os.path
 from decouple import config
 import dj_database_url
 import django_cache_url
+import functools
 
 CONF_ROOT = os.path.dirname(__file__)
 DATA_DIR = config('SENTRY_DATA_DIR', default='/data')
@@ -240,3 +241,27 @@ if SENTRY_USE_LDAP:
     logger.addHandler(logging.StreamHandler())
     ldap_loglevel = getattr(logging, config('LDAP_LOGLEVEL', default='DEBUG'))
     logger.setLevel(ldap_loglevel)
+
+##############################
+# REMOTE_USER authentication #
+##############################
+
+SENTRY_USE_REMOTE_USER = config('SENTRY_USE_REMOTE_USER', default=False, cast=bool)
+
+if SENTRY_USE_REMOTE_USER:
+    AUTHENTICATION_BACKENDS += ('django.contrib.auth.backends.RemoteUserBackend',)
+
+    AUTH_REMOTE_USER_HEADER = config('AUTH_REMOTE_USER_HEADER', default=None)
+    if AUTH_REMOTE_USER_HEADER:
+        # The lazy hack is required because importing RemoteUserMiddleware at load time leads to a circular import
+        # The name is upper camel case because that's the only way to expose values from this config file
+        def build_LAZY_CUSTOM_REMOTE_USER_MIDDLEWARE(header, *args, **kwargs):
+            from django.contrib.auth.middleware import RemoteUserMiddleware
+            class CustomRemoteUserMiddleware(RemoteUserMiddleware):
+               pass
+            CustomRemoteUserMiddleware.header = header
+            return CustomRemoteUserMiddleware(*args, **kwargs)
+        LAZY_CUSTOM_REMOTE_USER_MIDDLEWARE = functools.partial(build_LAZY_CUSTOM_REMOTE_USER_MIDDLEWARE, AUTH_REMOTE_USER_HEADER)
+        MIDDLEWARE_CLASSES += ('sentry_config.LAZY_CUSTOM_REMOTE_USER_MIDDLEWARE',)
+    else:
+        MIDDLEWARE_CLASSES += ('django.contrib.auth.middleware.RemoteUserMiddleware',)


### PR DESCRIPTION
Useful when Sentry is used behind a company-wide SSO.