### PR TITLE
[slack] add sentry-slack==0.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN mkdir -p /conf /data /wheels
 ADD requirements.txt /conf/
 
 RUN pip wheel --wheel-dir=/wheels -r /conf/requirements.txt && pip install --find-links=/wheels -r /conf/requirements.txt
+RUN pip install sentry-slack
 
 EXPOSE 9000
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ nydus==0.10.8
 
 # sentry
 sentry[postgres]==7.4.3
+sentry-slack==0.2.0
 
 # ldap user store
 django-auth-ldap==1.2.6


### PR DESCRIPTION
Hi,

Thank you for your work on `sentry-docker`!

Here is a way to add the `sentry-slack` plugin, which I need.

Please note that before I added it to the `Dockerfile`, I first tried to add it in the `requirements.txt`, but for whatever reason it did not work. I haven't really searched why, but I suspect it is because of the `wheel` command.

Best regards