### PR TITLE
Improvements settings and defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ SENTRY_USE_REDIS_BUFFER         |                                               
 SENTRY_REDIS_BUFFERS            | SENTRY_REDIS_OPTIONS['hosts']*                | list | ``<SENTRY_REDIS_HOST>:<SENTRY_REDIS_PORT>``           | comma separated list of redis hosts (``host1:port1,host2:port2,...``)
 SENTRY_USE_REDIS_TSDB           |                                               | bool | False                                                 |
 SENTRY_REDIS_TSDBS              | SENTRY_TSDB_OPTIONS['hosts']*                 | list | ``<SENTRY_REDIS_HOST>:<SENTRY_REDIS_PORT>``           | comma separated list of redis hosts (``host1:port1,host2:port2,...``)
+MANDRILL_API_KEY                |                                               |      | None                                                  | API Key for Mandrill. If `$MANDRILL_API_KEY` is set and `$SENTRY_EMAIL_BACKEND` is not, the later will be preselected to `'djrill.mail.backends.djrill.DjrillBackend'`.
 SENTRY_EMAIL_BACKEND            | EMAIL_BACKEND                                 |      | django.core.mail.backends.console.EmailBackend        |
 SENTRY_EMAIL_HOST               | EMAIL_HOST                                    |      | localhost                                             |
 SENTRY_EMAIL_HOST_PASSWORD      | EMAIL_HOST_PASSWORD                           |      | ''                                                    |
@@ -222,6 +223,7 @@ SENTRY_ADMIN_USERNAME           |                                               
 SENTRY_ADMIN_PASSWORD           |                                               |      | admin                                                 | password for Sentry's superuser
 SENTRY_ADMIN_EMAIL              | SENTRY_ADMIN_EMAIL                            |      | root@localhost                                        | email address for Sentry's superuser and a setting as of Sentry 7.3
 SENTRY_DATA_DIR                 |                                               |      | ``/data``                                             | custom location for logs and sqlite database
+ALLOWED_HOSTS                   | ALLOWED_HOSTS                                 | list | [urlparse(SENTRY_URL_PREFIX).netloc]                  | "A list of strings representing the host/domain names that this Django site can serve" (https://docs.djangoproject.com/en/1.6/ref/settings/#allowed-hosts). If not defined, then the `SENTRY_URL_PREFIX` value will be parsed as a URL and the `netloc` component will be used.
 TWITTER_CONSUMER_KEY            | TWITTER_CONSUMER_KEY                          |      | ''                                                    |
 TWITTER_CONSUMER_SECRET         | TWITTER_CONSUMER_SECRET                       |      | ''                                                    |
 FACEBOOK_APP_ID                 | FACEBOOK_APP_ID                               |      | ''                                                    |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # env config
-python-decouple==2.3
+python-decouple==3.0
 django-cache-url==1.0.0
 dj-database-url==0.3.0
 
@@ -13,3 +13,5 @@ sentry[postgres]==7.7.0
 # ldap user store
 django-auth-ldap==1.2.6
 
+# Mandrillapp.com integration
+djrill==1.4.0

--- a/sentry_docker_conf.py
+++ b/sentry_docker_conf.py
@@ -1,6 +1,6 @@
 # This file is just Python, with a touch of Django which means you
 # you can inherit and tweak settings to your hearts content.
-from urlparse import urlparse
+from urlparse import urlsplit
 import os.path
 
 from decouple import config
@@ -184,7 +184,7 @@ BITBUCKET_CONSUMER_SECRET = config('BITBUCKET_CONSUMER_SECRET', default='')
 ALLOWED_HOSTS = config(
     'ALLOWED_HOSTS',
     cast=lambda v: [s.strip() for s in v.split(',')],
-    default=urlparse(SENTRY_URL_PREFIX).netloc,
+    default=urlsplit(SENTRY_URL_PREFIX).netloc,
 )
 
 LOGGING['disable_existing_loggers'] = False


### PR DESCRIPTION
- Use JSON instead of Pickle to serialize Celery messages
- Configurable `ALLOWED_HOSTS` (a comma-separated list). For convenience,
  defaults to `urlparse(SENTRY_URL_PREFIX).netloc`
- Mandrillapp.com integration: Simply define `$MANDRILL_API_KEY` and it
  will be used. If `$MANDRILL_API_KEY` is defined but you want to use
  another backend, simply define `$SENTRY_EMAIL_BACKEND`.
- Added `djrill` package to the requirements file.
- Upgraded version of `python-decouple` package.