### PR TITLE
Fixed typographical error, changed adminstrator to administrator in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ SENTRY_ADMIN_EMAIL=slafs@foo.com
 
 See [django docs](https://docs.djangoproject.com/en/1.5/ref/django-admin/#createsuperuser) for details about ``createsuperuser`` command.
 
-The default adminstrator username is ``admin`` with password ``admin`` (and ``root@localhost`` as email adress).
+The default administrator username is ``admin`` with password ``admin`` (and ``root@localhost`` as email adress).
 
 ### Postgres
 


### PR DESCRIPTION
@slafs, I've corrected a typographical error in the documentation of the [sentry-docker](https://github.com/slafs/sentry-docker) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.