### PR TITLE
Pinned python 2.7.10 and reverted kombu pin, for plugin support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:2.7.10
 
 MAINTAINER Sławek Ehlert <slafs@op.pl>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,9 +10,6 @@ hiredis==0.2.0
 # sentry
 sentry[postgres]==7.7.4
 
-# quickfix for issue #44
-kombu==3.0.30
-
 # ldap user store
 django-auth-ldap==1.2.7
 


### PR DESCRIPTION
I think you should consider this as a better fix for https://github.com/slafs/sentry-docker/issues/44 

With kombu==3.0.30 and sentry==7.7.4 I was getting 

Failed to load plugin 'slack':
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/sentry/utils/runner.py", line 255, in install_plugins
    plugin = ep.load()
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2379, in load
    self.require(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2396, in require
    items = working_set.resolve(reqs, env, installer)
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 854, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
ContextualVersionConflict: (kombu 3.0.30 (/usr/local/lib/python2.7/site-packages), Requirement.parse('kombu<3.0.27'), set(['sentry']))

When trying to use plugins.

I think its better to pin python:2.7.10 if you are using sentry < 8.1

