### PR TITLE
Sentry 8.0 (8.0.1)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ django-redis==4.3.0
 hiredis==0.2.0
 
 # sentry
-sentry[postgres]==7.7.4
+sentry[postgres]==8.0.1
 
 # quickfix for issue #44
 kombu==3.0.30

--- a/sentry_docker_conf.py
+++ b/sentry_docker_conf.py
@@ -45,6 +45,13 @@ def nydus_config(from_env_var):
         'hosts': _redis_hosts
     }
 
+############################
+# General Sentry options ##
+############################
+SENTRY_OPTIONS = {
+    'system.url-prefix': config('SENTRY_URL_PREFIX'),
+    'system.admin-email': config('SENTRY_ADMIN_EMAIL', default='root@localhost'),
+}
 
 ###########
 # Queue ##
@@ -100,9 +107,6 @@ if SENTRY_USE_REDIS_TSDB:
 ################
 # Web Server ##
 ################
-
-# You MUST configure the absolute URI root for Sentry:
-SENTRY_URL_PREFIX = config('SENTRY_URL_PREFIX')  # No trailing slash!
 
 # If you're using a reverse proxy, you should enable the X-Forwarded-Proto
 # and X-Forwarded-Host headers, and uncomment the following settings
@@ -177,10 +181,10 @@ BITBUCKET_CONSUMER_SECRET = config('BITBUCKET_CONSUMER_SECRET', default='')
 
 # custom settings
 ALLOWED_HOSTS = ['*']
+INTERNAL_IPS = config('INTERNAL_IPS', default='') # TODO: Milan check of dit werkt
 LOGGING['disable_existing_loggers'] = False
 
 SENTRY_BEACON = config('SENTRY_BEACON', default=True, cast=bool)
-SENTRY_ADMIN_EMAIL = config('SENTRY_ADMIN_EMAIL', default='root@localhost')
 
 ####################
 # LDAP settings ##


### PR DESCRIPTION
sentry-docker with Sentry 8.0.1
I had to make some minor tweaks.

In Sentry 8:
- The owner of an organization is stored separately as an OrganizationMember.
- Projects do no longer have a 'platform' field. I left the parameter in the create_project function because of possible backwards compatibility needs. Not sure if that's needed, but just to be safe.

All tests are running succesfully and it works great. Only bad thing is that - even when inited with a org./team/project - you have to follow the first-time-setup-wizard. I'm not sure how to disable it.